### PR TITLE
Issue/2

### DIFF
--- a/art_node.go
+++ b/art_node.go
@@ -51,6 +51,18 @@ type ArtNode struct {
 	nodeType uint8
 }
 
+func NewLeafNode(key []byte, value interface{}) *ArtNode {
+	newKey := make([]byte, len(key))
+	copy(newKey, key)
+	l := &ArtNode{
+		key:      newKey,
+		value:    value,
+		nodeType: LEAF,
+	}
+
+	return l
+}
+
 // From the specification: The smallest node type can store up to 4 child
 // pointers and uses an array of length 4 for keys and another
 // array of the same length for pointers. The keys and pointers

--- a/art_node_test.go
+++ b/art_node_test.go
@@ -213,3 +213,25 @@ func TestShrink(t *testing.T) {
 		}
 	}
 }
+
+func TestNewLeafNode(t *testing.T) {
+	key := []byte{'a', 'r', 't' }
+	value := "tree"
+	l := NewLeafNode(key, value)
+
+	if &l.key == &key {
+		t.Errorf("Address of key byte slices should not match.")
+	}
+
+	if bytes.Compare(l.key, key) != 0 {
+		t.Errorf("Expected key value to match the one supplied")
+	}
+
+	if l.value != value {
+		t.Errorf("Expected initial value to match the one supplied")
+	}
+
+	if l.nodeType != LEAF {
+		t.Errorf("Expected Leaf node to be of LEAF type")
+	}
+}

--- a/art_tree.go
+++ b/art_tree.go
@@ -82,7 +82,7 @@ func (t *ArtTree) insertHelper(current *ArtNode, currentRef **ArtNode, key []byt
 	//        simply be inserted into an existing inner node, after growing
 	//        it if necessary.
 	if current == nil {
-		*currentRef = &ArtNode{key: key, value: value, nodeType: LEAF}
+		*currentRef = NewLeafNode(key, value)
 		t.size += 1
 		return
 	}
@@ -100,7 +100,7 @@ func (t *ArtTree) insertHelper(current *ArtNode, currentRef **ArtNode, key []byt
 
 		// Create a new Inner Node to contain the new Leaf and the current node.
 		newNode4 := NewNode4()
-		newLeafNode := &ArtNode{key: key, value: value, nodeType: LEAF}
+		newLeafNode := NewLeafNode(key, value)
 
 		// Determine the longest common prefix between our current node and the key
 		limit := current.LongestCommonPrefix(newLeafNode, depth)
@@ -150,7 +150,7 @@ func (t *ArtTree) insertHelper(current *ArtNode, currentRef **ArtNode, key []byt
 			}
 
 			// Attach the desired insertion key
-			newLeafNode := &ArtNode{key: key, value: value, nodeType: LEAF}
+			newLeafNode := NewLeafNode(key, value)
 			newNode4.AddChild(key[depth+mismatch], newLeafNode)
 
 			t.size += 1
@@ -171,7 +171,7 @@ func (t *ArtTree) insertHelper(current *ArtNode, currentRef **ArtNode, key []byt
 
 	} else {
 		// Otherwise, Add the child at the current position.
-		current.AddChild(key[depth], &ArtNode{key: key, value: value, nodeType: LEAF})
+		current.AddChild(key[depth], NewLeafNode(key, value))
 		t.size += 1
 	}
 }

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -7,6 +7,8 @@ import (
 	_ "log"
 	"os"
 	"testing"
+	"encoding/binary"
+	"math/rand"
 )
 
 // @spec: After a single insert operation, the tree should have a size of 1
@@ -701,5 +703,35 @@ func TestInsertManyUUIDsAndRemoveThemAll(t *testing.T) {
 
 	if tree.root != nil {
 		t.Error("Tree is expected to be nil after removing many uuids")
+	}
+}
+
+// Regression test for issue/2
+func TestInsertWithSameByteSliceAddress(t *testing.T) {
+	rand.Seed(42)
+	key := make([]byte, 8)
+	tree := NewArtTree()
+
+	// Keep track of what we inserted
+	keys := make(map[string]bool)
+	
+	
+	for i := 0; i < 135; i++ {
+		binary.BigEndian.PutUint64(key, uint64(rand.Int63()))
+		tree.Insert(key, key)
+
+		// Ensure that we can search these records later
+		keys[string(key)] = true
+	}
+
+	if tree.size != int64(len(keys)) {
+		t.Errorf("Mismatched size of tree and expected values.  Expected: %d.  Actual: %d\n", len(keys), tree.size)
+	}
+
+	for k, _ := range keys {
+		n := tree.Search([]byte(k))
+		if !(n.(bool)) {
+			t.Errorf("Did not find entry for key: %v\n", []byte(k))
+		}
 	}
 }

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -3,12 +3,12 @@ package art
 import (
 	"bufio"
 	"bytes"
+	"encoding/binary"
 	_ "fmt"
 	_ "log"
+	"math/rand"
 	"os"
 	"testing"
-	"encoding/binary"
-	"math/rand"
 )
 
 // @spec: After a single insert operation, the tree should have a size of 1
@@ -714,8 +714,7 @@ func TestInsertWithSameByteSliceAddress(t *testing.T) {
 
 	// Keep track of what we inserted
 	keys := make(map[string]bool)
-	
-	
+
 	for i := 0; i < 135; i++ {
 		binary.BigEndian.PutUint64(key, uint64(rand.Int63()))
 		tree.Insert(key, key)
@@ -730,7 +729,7 @@ func TestInsertWithSameByteSliceAddress(t *testing.T) {
 
 	for k, _ := range keys {
 		n := tree.Search([]byte(k))
-		if !(n.(bool)) {
+		if n == nil{
 			t.Errorf("Did not find entry for key: %v\n", []byte(k))
 		}
 	}


### PR DESCRIPTION
Introduces `NewLeafNode`, which explicitly copies the contents of the passed in `key` such that a re-used slice isn't addressed during Insert operations.  Aims to address issue #2 .

Also introduces the example code provided in the issue ticket as a regression test and a test for ensuring that `NewLeafNode` behaves as expected.