### PR TITLE
also resolves #9, channelized interfaces

### DIFF
--- a/art_node.go
+++ b/art_node.go
@@ -143,7 +143,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 
 	} else {
 
-		for ; index < n.prefixLen; index++ {
+		for ; index < n.prefixLen && index < len(key); index++ {
 			if key[depth+index] != n.prefix[index] {
 				return index
 			}

--- a/art_node.go
+++ b/art_node.go
@@ -143,7 +143,7 @@ func (n *ArtNode) PrefixMismatch(key []byte, depth int) int {
 
 	} else {
 
-		for ; index < n.prefixLen && index < len(key); index++ {
+		for ; index < n.prefixLen && depth+index < len(key); index++ {
 			if key[depth+index] != n.prefix[index] {
 				return index
 			}

--- a/art_node_test.go
+++ b/art_node_test.go
@@ -215,7 +215,7 @@ func TestShrink(t *testing.T) {
 }
 
 func TestNewLeafNode(t *testing.T) {
-	key := []byte{'a', 'r', 't' }
+	key := []byte{'a', 'r', 't'}
 	value := "tree"
 	l := NewLeafNode(key, value)
 

--- a/art_tree.go
+++ b/art_tree.go
@@ -3,12 +3,9 @@ package art
 
 import (
 	"bytes"
-	"fmt"
 	_ "math"
 	_ "os"
 )
-
-var _ = fmt.Println
 
 type ArtTree struct {
 	root *ArtNode
@@ -62,10 +59,7 @@ func (t *ArtTree) Search(key []byte) interface{} {
 	key = ensureNullTerminatedKey(key)
 	foundNode := t.searchHelper(t.root, key, 0)
 	if foundNode != nil {
-		// i think with the null terminated key, the return is always a leaf, or nil?
-		// if foundNode.IsLeaf() {
 		return foundNode.value
-		// }
 	}
 	return nil
 }

--- a/art_tree.go
+++ b/art_tree.go
@@ -78,7 +78,8 @@ func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode
 		}
 
 		// Check if our key mismatches the current compressed path
-		if current.PrefixMismatch(key, depth) != current.prefixLen {
+		prefixMismatch := current.PrefixMismatch(key, depth)
+		if prefixMismatch == 0 && prefixMismatch < current.prefixLen {
 			// Bail if there's a mismatch during traversal.
 			return nil
 		} else {

--- a/art_tree.go
+++ b/art_tree.go
@@ -21,7 +21,7 @@ func NewArtTree() *ArtTree {
 }
 
 type Result struct {
-	Key string
+	Key   string
 	Value interface{}
 }
 
@@ -64,7 +64,7 @@ func (t *ArtTree) Search(key []byte) interface{} {
 	if foundNode != nil {
 		// i think with the null terminated key, the return is always a leaf, or nil?
 		// if foundNode.IsLeaf() {
-			return foundNode.value
+		return foundNode.value
 		// }
 	}
 	return nil
@@ -75,7 +75,7 @@ func (t *ArtTree) Search(key []byte) interface{} {
 func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode {
 	// While we have nodes to search
 	if current != nil {
-		maxKeyIndex := len(key)-1
+		maxKeyIndex := len(key) - 1
 
 		// Check if the current is a match
 		if current.IsLeaf() {
@@ -300,7 +300,7 @@ func (t *ArtTree) EachChanFrom(start *ArtNode) chan *ArtNode {
 		t.eachHelper(start, nodeChan)
 		close(nodeChan)
 	}()
-	return nodeChan	
+	return nodeChan
 }
 
 // Recursive helper for iterative over the ArtTree.  Iterates over all nodes in the tree,

--- a/art_tree.go
+++ b/art_tree.go
@@ -3,10 +3,12 @@ package art
 
 import (
 	"bytes"
-	_ "fmt"
+	"fmt"
 	_ "math"
 	_ "os"
 )
+
+var _ = fmt.Println
 
 type ArtTree struct {
 	root *ArtNode
@@ -51,6 +53,7 @@ func (t *ArtTree) Search(key []byte) interface{} {
 func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode {
 	// While we have nodes to search
 	if current != nil {
+		maxKeyIndex := len(key)-1
 
 		// Check if the current is a match
 		if current.IsLeaf() {
@@ -60,6 +63,8 @@ func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode
 
 			// Bail if no match
 			return nil
+		} else if depth > maxKeyIndex {
+			return current
 		}
 
 		// Check if our key mismatches the current compressed path
@@ -69,7 +74,7 @@ func (t *ArtTree) searchHelper(current *ArtNode, key []byte, depth int) *ArtNode
 		} else {
 			// Otherwise, increase depth accordingly.
 			depth += current.prefixLen
-			if depth > len(key)-1 {
+			if depth > maxKeyIndex {
 				return current
 			}
 		}

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -837,3 +837,27 @@ func TestPrefixSearch2(t *testing.T) {
 		}
 	}
 }
+
+func TestPrefixSearch3(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"foo:bar", "a", "foo:baz",
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	rr := tree.PrefixSearch([]byte("foo:b"))
+	if rr == nil {
+		t.Error("something should have been found for foo:b")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "foo:bar,foo:baz," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+}

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -729,8 +729,76 @@ func TestInsertWithSameByteSliceAddress(t *testing.T) {
 
 	for k, _ := range keys {
 		n := tree.Search([]byte(k))
-		if n == nil{
+		if n == nil {
 			t.Errorf("Did not find entry for key: %v\n", []byte(k))
 		}
 	}
+}
+
+func TestPrefixSearch(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"abcd", "abde", "abfg", "abgh",
+		"abcfgh", "abezyx",
+		"bcdef", "bcdi", "bcdgh", "abef", 
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	res := tree.Search([]byte("abezyx"))
+	if res != "abezyx" {
+		t.Error("Unexpected search result.")
+	}
+
+	rr := tree.PrefixSearch([]byte("x"))
+	if rr != nil {
+		t.Error("shouldn't be found", rr)
+	}
+
+	rr = tree.PrefixSearch([]byte("ax"))
+	if rr != nil {
+		t.Error("shouldn't be found", rr)
+	}
+
+	rr = tree.PrefixSearch([]byte("abc"))
+	if rr == nil {
+		t.Error("something should have been found for abc")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "abcd,abcfgh," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+
+	rr = tree.PrefixSearch([]byte("ab"))
+	if rr == nil {
+		t.Error("something should have been found for abc")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "abcd,abcfgh,abde,abef,abezyx,abfg,abgh," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+
+	rr = tree.PrefixSearch([]byte("bcd"))
+	if rr == nil {
+		t.Error("something should have been found for abc")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "bcdef,bcdgh,bcdi," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+
 }

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -753,26 +753,25 @@ func TestPrefixSearch(t *testing.T) {
 	}
 
 	rr := tree.PrefixSearch([]byte("x"))
-	if rr != nil {
+	if rr == nil {
+		t.Error("empty results empty arrays")
+	} else if len(rr) > 0 {
 		t.Error("shouldn't be found", rr)
 	}
 
 	rr = tree.PrefixSearch([]byte("ax"))
-	if rr != nil {
+	if rr == nil {
+		t.Error("empty results empty arrays")
+	} else if len(rr) > 0 {
 		t.Error("shouldn't be found", rr)
 	}
 
-	rr = tree.PrefixSearch([]byte("abc"))
-	if rr == nil {
-		t.Error("something should have been found for abc")
-	} else {
-		ss := ""
-		for _, s := range rr {
-			ss += s.(string) + ","
-		}
-		if ss != "abcd,abcfgh," {
-			t.Error("array didn't match, got", ss)
-		}
+	rs := ""
+	for res := range tree.PrefixSearchChan([]byte("abc")) {
+		rs += res.(string) + ","
+	}
+	if rs != "abcd,abcfgh," {
+		t.Error("array didn't match, got", rs)
 	}
 
 	rr = tree.PrefixSearch([]byte("ab"))

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -801,4 +801,16 @@ func TestPrefixSearch(t *testing.T) {
 		}
 	}
 
+	rr = tree.PrefixSearch([]byte("a"))
+	if rr == nil {
+		t.Error("something should have been found for a")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "abcd,abcfgh,abde,abef,abezyx,abfg,abgh," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
 }

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -813,3 +813,27 @@ func TestPrefixSearch(t *testing.T) {
 		}
 	}
 }
+
+func TestPrefixSearch2(t *testing.T) {
+	tree := NewArtTree()
+
+	searchWords := []string{
+		"ab", "abc",
+	}
+
+	for _, s := range searchWords {
+		tree.Insert([]byte(s), s)
+	}
+	rr := tree.PrefixSearch([]byte("a"))
+	if rr == nil {
+		t.Error("something should have been found for abc")
+	} else {
+		ss := ""
+		for _, s := range rr {
+			ss += s.(string) + ","
+		}
+		if ss != "ab,abc," {
+			t.Error("array didn't match, got", ss)
+		}
+	}
+}

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -741,7 +741,7 @@ func TestPrefixSearch(t *testing.T) {
 	searchWords := []string{
 		"abcd", "abde", "abfg", "abgh",
 		"abcfgh", "abezyx",
-		"bcdef", "bcdi", "bcdgh", "abef", 
+		"bcdef", "bcdi", "bcdgh", "abef",
 	}
 
 	for _, s := range searchWords {

--- a/art_tree_test.go
+++ b/art_tree_test.go
@@ -768,7 +768,7 @@ func TestPrefixSearch(t *testing.T) {
 
 	rs := ""
 	for res := range tree.PrefixSearchChan([]byte("abc")) {
-		rs += res.(string) + ","
+		rs += res.Value.(string) + ","
 	}
 	if rs != "abcd,abcfgh," {
 		t.Error("array didn't match, got", rs)


### PR DESCRIPTION
on top of https://github.com/kellydunn/go-art/pull/10 adds a more idiomatic interface to the iterators, using channels as opposed to callbacks.  kept the original api for backwards compatibility
